### PR TITLE
Retry logic when failing

### DIFF
--- a/gcp-cloud-sql-serverless-patch/pom.xml
+++ b/gcp-cloud-sql-serverless-patch/pom.xml
@@ -14,6 +14,22 @@
       <artifactId>jdbc-socket-factory-core</artifactId>
       <version>1.11.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -33,6 +49,11 @@
           <source>8</source>
           <target>8</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
       </plugin>
     </plugins>
   </build>

--- a/gcp-cloud-sql-serverless-patch/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
+++ b/gcp-cloud-sql-serverless-patch/src/test/java/com/google/cloud/sql/core/CloudSqlInstanceTest.java
@@ -1,0 +1,145 @@
+package com.google.cloud.sql.core;
+
+import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.cloud.sql.AuthType;
+import com.google.cloud.sql.CredentialFactory;
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.KeyPair;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudSqlInstanceTest {
+    private final String connectionName = "project:region:instance";
+
+    @Mock
+    private SqlAdminApiFetcher apiFetcher;
+
+    @Mock
+    private CredentialFactory tokenSourceFactory;
+
+    @Mock
+    private ListeningScheduledExecutorService executor;
+
+    @Mock
+    private ListenableFuture<KeyPair> keyPair;
+
+    @BeforeEach
+    public void setup() {
+        when(tokenSourceFactory.create()).thenReturn(
+            new Credential.Builder(BearerToken.authorizationHeaderAccessMethod()).build()
+        );
+    }
+
+    @Test
+    public void shouldBeAbleToFetchData() throws Exception {
+        SslData sslData = createSslData();
+        when(apiFetcher.getInstanceData(any(), any(), eq(AuthType.IAM), any(), any())).thenReturn(
+            new ResolvedFuture(validInstanceData(sslData))
+        );
+
+        CloudSqlInstance inst = new CloudSqlInstance(connectionName, apiFetcher, AuthType.IAM, tokenSourceFactory, executor, keyPair);
+        SslData result = inst.getSslData();
+        assertEquals(sslData, result);
+        verify(apiFetcher, times(1)).getInstanceData(any(), any(), eq(AuthType.IAM), any(), any());
+    }
+
+    @Test
+    public void failOnStartupShouldRetryOnce() throws Exception {
+        SslData sslData = createSslData();
+        when(apiFetcher.getInstanceData(any(), any(), eq(AuthType.IAM), any(), any()))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new ResolvedFuture(validInstanceData(sslData)));
+
+        CloudSqlInstance inst = new CloudSqlInstance(connectionName, apiFetcher, AuthType.IAM, tokenSourceFactory, executor, keyPair);
+        SslData result = inst.getSslData();
+        assertEquals(sslData, result);
+        verify(apiFetcher, times(2)).getInstanceData(any(), any(), eq(AuthType.IAM), any(), any());
+    }
+
+    @Test
+    public void failOnRefreshShouldRetryOnce() throws Exception {
+        SslData sslData = createSslData();
+        when(apiFetcher.getInstanceData(any(), any(), eq(AuthType.IAM), any(), any()))
+            .thenReturn(new ResolvedFuture(expiredInstanceData()))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new ResolvedFuture(validInstanceData(sslData)));
+
+        CloudSqlInstance inst = new CloudSqlInstance(connectionName, apiFetcher, AuthType.IAM, tokenSourceFactory, executor, keyPair);
+        assertThrows(RuntimeException.class, inst::getSslData);
+        SslData result = inst.getSslData();
+        assertEquals(sslData, result);
+        verify(apiFetcher, times(4)).getInstanceData(any(), any(), eq(AuthType.IAM), any(), any());
+    }
+
+    @Test
+    public void failTwiceOnStartupShouldRetryOnNextRefresh() throws Exception {
+        SslData sslData = createSslData();
+        when(apiFetcher.getInstanceData(any(), any(), eq(AuthType.IAM), any(), any()))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new ResolvedFuture(validInstanceData(sslData)));
+
+        CloudSqlInstance inst = new CloudSqlInstance(connectionName, apiFetcher, AuthType.IAM, tokenSourceFactory, executor, keyPair);
+        SslData result = inst.getSslData();
+        assertEquals(sslData, result);
+        verify(apiFetcher, times(3)).getInstanceData(any(), any(), eq(AuthType.IAM), any(), any());
+    }
+
+    @Test
+    public void failTwiceOnRefreshShouldRetryOnNextRefresh() throws Exception {
+        SslData sslData = createSslData();
+        when(apiFetcher.getInstanceData(any(), any(), eq(AuthType.IAM), any(), any()))
+            .thenReturn(new ResolvedFuture(expiredInstanceData()))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new RejectedFuture(new RuntimeException("knas")))
+            .thenReturn(new ResolvedFuture(validInstanceData(sslData)));
+
+        CloudSqlInstance inst = new CloudSqlInstance(connectionName, apiFetcher, AuthType.IAM, tokenSourceFactory, executor, keyPair);
+        assertThrows(RuntimeException.class, inst::getSslData);
+        SslData result = inst.getSslData();
+        assertEquals(sslData, result);
+        verify(apiFetcher, times(4)).getInstanceData(any(), any(), eq(AuthType.IAM), any(), any());
+    }
+
+    static class ResolvedFuture extends AbstractFuture<InstanceData> {
+        public ResolvedFuture(InstanceData data) {
+            set(data);
+        }
+    }
+
+    static class RejectedFuture extends AbstractFuture<InstanceData> {
+        public RejectedFuture(Throwable t) {
+            setException(t);
+        }
+    }
+
+    SslData createSslData() {
+        return new SslData(null, null, null);
+    }
+
+    InstanceData validInstanceData(SslData sslData) {
+        return new InstanceData(null, sslData, new Date(System.currentTimeMillis() + 3600000));
+    }
+
+    InstanceData expiredInstanceData() {
+        return new InstanceData(null, createSslData(), new Date(System.currentTimeMillis() - 1000));
+    }
+}


### PR DESCRIPTION
## Description

The previous logic was designed to run in the background, always keeping a DB access token available. The patched logic instead fetches an access token when a DB query is made, unless there is a cached one.

If the `currentInstanceData` future is set to a rejected future, then the following is supposed to happen when running in the background:
- The background job is constantly trying to get a new token
- When successful, `currentInstanceData` is updated with the new token
- Requests are using the previous token until the background job completes

If the `currentInstanceData` future is set to a rejected future, what happens is:
- Calls to get an access token are immediately rejected
- A background job is run to retry, but it is not included in the current call chain, it will update the result asynchronously

Changes:
- Simplified the `performRefresh()` method, to fit better in an environment where tokens are fetched when needed
- Updated the `performRefresh()` method to always retry once on failure, and not to return until the retry is performed
- Updated the calls that check for a valid token to also check for failed requests, and refresh if the previous attempt was failed